### PR TITLE
Print Error level output on stderr not stdout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.22.1
 
 sudo: false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplog"
-version = "1.0.3"
+version = "1.1.0"
 authors = ["Andrew Mackenzie <andrew@mackenzie-serres.net>"]
 description = "An extremely small and simple logger that has levels of output"
 license = "MIT"
@@ -10,4 +10,4 @@ name = "simplog"
 path = "src/lib.rs"
 
 [dependencies]
-log = "0.3.8"
+log = "0.4.6"


### PR DESCRIPTION
Log output printed as LogLevel ERROR is printed on stderr, not stdout